### PR TITLE
[Logging] Fix log timestamps intermittently missing fractional seconds

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -58,6 +58,12 @@ func CreateLogger(writer io.Writer, instanceName string, level zerolog.Level, lo
 }
 
 func setGlobalHandlers() {
+	// ecszerolog.New() sets TimeFieldFormat to "2006-01-02T15:04:05.999Z", whose ".999" layout
+	// drops the fractional part entirely when it's zero, producing timestamps like
+	// "2026-08-12T14:18:05Z" instead of "2026-08-12T14:18:05.000Z". Reassert a fixed-width
+	// format here so fractional seconds are always present.
+	zerolog.TimeFieldFormat = "2006-01-02T15:04:05.000Z"
+
 	zerolog.TimestampFunc = func() time.Time {
 		return time.Now().In(time.Local) //nolint:gosmopolitan // We want local time inside logger.
 	}


### PR DESCRIPTION
## What Changed

* `setGlobalHandlers()` in `logging/logging.go` now reasserts `zerolog.TimeFieldFormat` to a fixed-width `2006-01-02T15:04:05.000Z` format, after `ecszerolog.New()` runs.

## Why It Was Necessary

The `go.elastic.co/ecszerolog` dependency sets `zerolog.TimeFieldFormat` to `"2006-01-02T15:04:05.999Z"`. Go's `.999` layout specifier trims trailing zero fractional digits, and drops the fractional part (and the decimal point) entirely when the timestamp lands exactly on a whole second. This produced log timestamps like `2026-08-12T14:18:05Z` instead of the expected `2026-08-12T14:18:05.000Z`, roughly 1 in 1000 times.

This surfaced as an intermittent CI failure in `TestLoggingError`, whose `@timestamp` assertion (via `jsonrequire`'s `matchTimestamp` regex) requires fractional seconds to always be present. It's a real formatting bug rather than pure test flakiness — any consumer of our ECS-formatted logs expecting a consistent timestamp shape was affected.

## Testing Performed

* `TestLoggingError` run 50x in a loop (`go test ./errdef/... -run TestLoggingError -count=50`) — previously reproducible failure on whole-second timestamps no longer occurs.
* Full local verification via the project's standard checks:
  * `magex format:fix`
  * `go-pre-commit run --all-files`
  * `magex lint`
  * `magex test:race` (full suite, all packages passing)

## Impact / Risk

* **Breaking Change**: None — this only changes the formatting of the `@timestamp` field in log output (now always includes millisecond-precision fractional seconds instead of sometimes omitting them).
* **Risk**: Low — single-file change, scoped to log timestamp formatting.
* **Performance**: None.
* **Migration**: None required.